### PR TITLE
chore: Add Controller test helpers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
         "/node_modules/",
         "/dist/"
     ],
+    collectCoverageFrom: [
+        "src/**/{!(server),}.ts"
+    ],
     transform: {
         "^.+\\.(ts|tsx)$": "ts-jest"
     }

--- a/test/HtmlPatternAssertions.ts
+++ b/test/HtmlPatternAssertions.ts
@@ -1,0 +1,54 @@
+export function expectToHaveLink(body: string, href: string, linkText: string) {
+  const patternStr = `<a.* href="${href}">\\s*${linkText}\\s*<\/a>`;
+  const pattern = new RegExp(patternStr, 's');
+  expect(body).toMatch(pattern);
+}
+
+export function expectToHaveInput(body: string, field: string, label: string) {
+  const patternStr = `<label.*>\\s*${label}\\s*<\/label>.*<input.*name="${field}".*>`;
+  const pattern = new RegExp(patternStr, 's');
+  expect(body).toMatch(pattern);
+}
+
+export function expectToHaveErrorMessages(body: string, expectedErrors: string[]) {
+  expectedErrors.forEach(error => {
+    const patternStr = `<span.*class="govuk-error-message">.*${error}.*<\/span>`
+    const pattern = new RegExp(patternStr, 's');
+    expect(body).toMatch(pattern)
+  });
+}
+
+export function expectToHaveErrorSummaryContaining(body: string, expectedErrors: string[]) {
+  const summaryPattern = /<div class="govuk-error-summary".*>/s;
+  expect(body).toMatch(summaryPattern);
+
+  const errorListPattern = /(?<list><ul class="govuk-list govuk-error-summary__list">(?:.*?)<\/ul>)/s;
+  const errorList = errorListPattern.exec(body)?.groups?.list;
+  if (errorList) {
+    const errorPattern = /<a(?:.*?)>(?<text>.*?)<\/a>/gs;
+    const receivedErrors: (string | undefined)[] = [];
+    let match = errorPattern.exec(errorList);
+    while (match) {
+      receivedErrors.push(match.groups?.text);
+      match = errorPattern.exec(errorList);
+    }
+    expectedErrors.forEach(error => {
+      expect(receivedErrors).toContain(error);
+    });
+    expect(receivedErrors.length).toEqual(expectedErrors.length);
+  } else {
+    fail('Expected to find an Error Summary list in the HTML body')
+  }
+}
+
+export function expectToHaveTitle(body: string, expectedTitle: string) {
+  const patternStr = `<title>\\s*${expectedTitle}\\s*<\/title>`;
+  const pattern = new RegExp(patternStr, 's');
+  expect(body).toMatch(pattern);
+}
+
+export function expectNotToHaveTitle(body: string, invalidTitle: string) {
+  const patternStr = `<title>\\s*${invalidTitle}\\s*<\/title>`;
+  const pattern = new RegExp(patternStr, 's');
+  expect(body).not.toMatch(pattern);
+}

--- a/test/controllers/StartPageController.test.ts
+++ b/test/controllers/StartPageController.test.ts
@@ -14,7 +14,6 @@ describe('StartPageController', () => {
 
       await request(app).get(ROOT_URI).expect(response => {
         expect(response.status).toEqual(OK);
-        expect(response.text).toContain(expectedTitle);
         expectToHaveTitle(response.text, expectedTitle)
         expectToHaveLink(response.text,
           'https:\/\/www.gov.uk\/government\/publications\/restricting-the-disclosure-of-your-psc-information',

--- a/test/controllers/StartPageController.test.ts
+++ b/test/controllers/StartPageController.test.ts
@@ -3,27 +3,26 @@ import * as request from 'supertest';
 
 import app from '../../src/app';
 import { ROOT_URI } from '../../src/routes/paths';
+import { expectToHaveLink, expectToHaveTitle } from '../HtmlPatternAssertions'
 
 describe('StartPageController', () => {
 
-    describe('on GET', () => {
+  describe('on GET', () => {
 
-        it('should return 200 and render the Service Start Page', async () => {
-            const expectedPatterns = [
-                /Apply to remove your home address from the Companies House register/,
-                /Use this service to apply to remove your home address, or part of it, from the Companies House public register \(SR01\)\./,
-                /<a.*>\s*Restricting the disclosure of your information\s*<\/a>/,
-                /<a.* href="https:\/\/www.gov.uk\/government\/publications\/restricting-the-disclosure-of-your-psc-information">.*<\/a>/s,
-                /<a.*>\s*Companies House register\s*<\/a>/,
-                /<a.* href="https:\/\/beta.companieshouse.gov.uk\/">.*<\/a>/s,
-            ];
+    it('should return 200 and render the Service Start Page', async () => {
+      const expectedTitle = 'Apply to remove your home address from the Companies House register';
 
-            await request(app).get(ROOT_URI).expect(response => {
-                expect(response.status).toEqual(OK);
-                expectedPatterns.forEach((pattern) => {
-                    expect(response.text).toMatch(pattern);
-                })
-            });
-        });
+      await request(app).get(ROOT_URI).expect(response => {
+        expect(response.status).toEqual(OK);
+        expect(response.text).toContain(expectedTitle);
+        expectToHaveTitle(response.text, expectedTitle)
+        expectToHaveLink(response.text,
+          'https:\/\/www.gov.uk\/government\/publications\/restricting-the-disclosure-of-your-psc-information',
+          'Restricting the disclosure of your information');
+        expectToHaveLink(response.text,
+          'https:\/\/beta.companieshouse.gov.uk\/',
+          'Companies House register');
+      });
     });
+  });
 });


### PR DESCRIPTION
### Change description

This commit adds common HTML pattern helpers to allow simplified testing of controllers. It also updates the Start Page Controller test to use these new helpers.

### Work Checklist

- [x] Tests added where applicable

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
