### PR TITLE
test: Fix broken import references in ValidationAssertions.ts

### DIFF
--- a/test/validators/ValidationAssertions.ts
+++ b/test/validators/ValidationAssertions.ts
@@ -1,5 +1,5 @@
-import { ValidationError } from '../../../src/validators/utils/ValidationError';
-import { ValidationResult } from '../../../src/validators/utils/ValidationResult';
+import { ValidationError } from '../../src/utils/validation/ValidationError';
+import { ValidationResult } from '../../src/utils/validation/ValidationResult';
 
 export const assertValidationErrors = (result: ValidationResult, expectedErrors: ValidationError[]): void => {
   expect(result.errors).toHaveLength(expectedErrors.length);


### PR DESCRIPTION
### Change description

Fix import references inside the validation test helpers, broken after validation logic restructure. Was not picked up by tests as no tests used them yet.

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
