### PR TITLE
fix: non calendar dates should trigger validation error

### DIFF
--- a/src/validators/DocumentDetailsValidator.ts
+++ b/src/validators/DocumentDetailsValidator.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express'
+import moment from 'moment';
 
 import { ValidationError } from '../utils/validation/ValidationError';
 import { ValidationResult } from '../utils/validation/ValidationResult';
@@ -24,7 +25,7 @@ export class DocumentDetailsValidator extends FormValidator {
     const dayValue = request.body[dayField];
 
     if (yearValue && monthValue && dayValue) {
-      request.body.date = new Date(`${yearValue}-${monthValue}-${dayValue}`);
+      request.body.date = moment(`${yearValue}-${monthValue}-${dayValue}`, 'YYYY-MM-DD').toDate();
     }
 
     const validationResult: ValidationResult = await super.validate(request);

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -24,35 +24,42 @@
       {% set classes_month = 'govuk-input--width-2' %}
       {% set classes_year = 'govuk-input--width-4' %}
       {% set documentDateErrorMessage = false %}
+      {% set hasDateError = false %}
 
       {% if validationResult and validationResult.errors.length > 0 %}
 
         {% if validationResult.getErrorForField('day') %}
           {% set classes_day = classes_day + ' govuk-input--error' %}
+          {% set hasDateError = true %}
         {% endif %}
         {% if validationResult.getErrorForField('month') %}
           {% set classes_month = classes_month + ' govuk-input--error' %}
+          {% set hasDateError = true %}
         {% endif %}
          {% if validationResult.getErrorForField('year') %}
           {% set classes_year = classes_year + ' govuk-input--error' %}
+          {% set hasDateError = true %}
         {% endif %}
         {% if validationResult.getErrorForField('date') %}
           {% set classes_day = classes_day + ' govuk-input--error' %}
           {% set classes_month = classes_month + ' govuk-input--error' %}
           {% set classes_year = classes_year + ' govuk-input--error' %}
+          {% set hasDateError = true %}
         {% endif %}
 
-        {% set errorMessages %}
-          <ul style="padding: 0;list-style-type: none;">
-            {% for error in validationResult.errors %}
-              {% if error.field in ['day', 'month', 'year', 'date'] %}
-                <li>
-                  {{ error.text }}
-                </li>
-              {% endif %}
-            {% endfor %}
-          </ul>
-        {% endset %}
+        {% if hasDateError %}
+          {% set errorMessages %}
+            <ul style="padding: 0;list-style-type: none;">
+              {% for error in validationResult.errors %}
+                {% if error.field in ['day', 'month', 'year', 'date'] %}
+                  <li>
+                    {{ error.text }}
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endset %}
+        {% endif %}
 
         {% if errorMessages %}
           {% set documentDateErrorMessage = {

--- a/test/validators/schema/DocumentDetailsSchema.test.ts
+++ b/test/validators/schema/DocumentDetailsSchema.test.ts
@@ -1,3 +1,5 @@
+import moment = require('moment');
+
 import { SchemaValidator } from '../../../src/utils/validation/SchemaValidator';
 import { ValidationError } from '../../../src/utils/validation/ValidationError';
 import { assertValidationErrors } from '../ValidationAssertions';
@@ -71,7 +73,7 @@ describe('Document Details schema', () => {
         day: '',
         month: '',
         year: '',
-        date: new Date('')
+        date: moment('', 'YYYY-MM-DD').toDate()
       });
       assertValidationErrors(validationResult, expectedValidationErrors
         .concat(new ValidationError('date', invalidDateErrorMessage)));
@@ -85,7 +87,7 @@ describe('Document Details schema', () => {
         day: ' ',
         month: ' ',
         year: ' ',
-        date: new Date(' ')
+        date: moment(' ', 'YYYY-MM-DD').toDate()
       });
       assertValidationErrors(validationResult, expectedValidationErrors
         .concat(new ValidationError('date', invalidDateErrorMessage)));
@@ -117,10 +119,55 @@ describe('Document Details schema', () => {
         day: '33',
         month: '01',
         year: '2020',
-        date: new Date('2020-01-33')
+        date: moment('2020-01-33', 'YYYY-MM-DD').toDate()
       });
       assertValidationErrors(validationResult, [
         new ValidationError('date', invalidDateErrorMessage)
+      ]);
+    });
+
+    it('should reject invalid calendar dates - feb 30th does not exist', () => {
+      const validationResult = validator.validate({
+        companyName: 'company-name-test',
+        companyNumber: 'NI000000',
+        description: 'This is a document',
+        day: '30',
+        month: '02',
+        year: '2015',
+        date: moment('2015-02-30', 'YYYY-MM-DD').toDate()
+      });
+      assertValidationErrors(validationResult, [
+        new ValidationError('date', 'Enter a real date')
+      ]);
+    });
+
+    it('should reject invalid calendar dates - april 31st does not exist', () => {
+      const validationResult = validator.validate({
+        companyName: 'company-name-test',
+        companyNumber: 'NI000000',
+        description: 'This is a document',
+        day: '31',
+        month: '04',
+        year: '2015',
+        date: moment('2015-04-31', 'YYYY-MM-DD').toDate()
+      });
+      assertValidationErrors(validationResult, [
+        new ValidationError('date', 'Enter a real date')
+      ]);
+    });
+
+    it('should reject 29th of feb during a non-leap year', () => {
+      const validationResult = validator.validate({
+        companyName: 'company-name-test',
+        companyNumber: 'NI000000',
+        description: 'This is a document',
+        day: '29',
+        month: '02',
+        year: '1997',
+        date: moment('1997-02-29', 'YYYY-MM-DD').toDate()
+      });
+      assertValidationErrors(validationResult, [
+        new ValidationError('date', 'Enter a real date')
       ]);
     });
   });
@@ -135,7 +182,20 @@ describe('Document Details schema', () => {
         day: '01',
         month: '01',
         year: '2020',
-        date: new Date('2020-01-01')
+        date: moment('2020-01-01', 'YYYY-MM-DD').toDate()
+      });
+      assertValidationErrors(validationResult, []);
+    });
+
+    it('should allow 29th of feb during a leap year', () => {
+      const validationResult = validator.validate({
+        companyName: 'company-name-test',
+        companyNumber: 'NI000000',
+        description: 'This is a document',
+        day: '29',
+        month: '02',
+        year: '1996',
+        date: moment('1996-02-29', 'YYYY-MM-DD').toDate()
       });
       assertValidationErrors(validationResult, []);
     });


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/SR-28

The document details page was not triggering a validation error for an invalid date input, for example 31/02/2020

### Change description
- Updated the document details validator to use momentjs when creating a new date from the day, month, year input
- Updated template to not show red line for date input when valid, but other inputs are invalid

### Page Screenshot

Fixed validation:
<img width="804" alt="Screenshot 2020-09-03 at 15 38 45" src="https://user-images.githubusercontent.com/16392604/92129566-9cb67980-edfb-11ea-84f0-b5f4f8691f97.png">


### Work Checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.