### PR TITLE
feat: Address to Remove <-> Document Details transition

### DIFF
--- a/src/controllers/AddressToRemoveController.ts
+++ b/src/controllers/AddressToRemoveController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes  } from 'http-status-codes';
 
 import { Address } from '../models/SuppressionDataModel'
-import { ADDRESS_TO_REMOVE_PAGE_URI } from '../routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
 import SessionService from '../services/SessionService'
 import { ValidationResult } from '../utils/validation/ValidationResult';
 import { FormValidator } from '../validators/FormValidator';
@@ -35,7 +35,7 @@ export class AddressToRemoveController {
     } else {
       session.addressToRemove = req.body as Address;
       SessionService.setSuppressionSession(req, session);
-      res.redirect(ADDRESS_TO_REMOVE_PAGE_URI);
+      res.redirect(DOCUMENT_DETAILS_PAGE_URI);
     }
   };
 }

--- a/src/controllers/DocumentDetailsController.ts
+++ b/src/controllers/DocumentDetailsController.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import moment from 'moment';
 
 import { DocumentDetails, SuppressionData } from '../models/SuppressionDataModel';
-import { DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
 import SessionService from '../services/SessionService';
 import { DocumentDetailsValidator } from '../validators/DocumentDetailsValidator';
 
@@ -17,7 +17,10 @@ export class DocumentDetailsController {
 
     const suppressionData = SessionService.getSuppressionSession(req);
 
-    res.render(template, { ...this.getDocumentDetails(suppressionData) });
+    res.render(template, {
+      ...this.getDocumentDetails(suppressionData),
+      backNavigation: ADDRESS_TO_REMOVE_PAGE_URI
+    });
   }
 
   public processForm = async (req: Request, res: Response, next: NextFunction) => {
@@ -28,7 +31,8 @@ export class DocumentDetailsController {
       res.status(StatusCodes.UNPROCESSABLE_ENTITY);
       return res.render(template, {
         ...req.body,
-        validationResult
+        validationResult,
+        backNavigation: ADDRESS_TO_REMOVE_PAGE_URI
       });
     }
 

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -4,9 +4,19 @@
 {% from 'govuk/components/input/macro.njk'         import govukInput %}
 {% from 'govuk/components/date-input/macro.njk'    import govukDateInput %}
 {% from 'govuk/components/button/macro.njk'        import govukButton %}
+{% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
 
 {% block pageTitle %}
   Document details
+{% endblock %}
+
+{% block backLink %}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: backNavigation
+    })
+  }}
 {% endblock %}
 
 {% block content %}

--- a/test/controllers/AddressToRemoveController.test.ts
+++ b/test/controllers/AddressToRemoveController.test.ts
@@ -1,8 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
-import { Address, ApplicantDetails, SuppressionData } from '../../src/models/SuppressionDataModel'
-import { ADDRESS_TO_REMOVE_PAGE_URI } from '../../src/routes/paths';
+import { Address, SuppressionData } from '../../src/models/SuppressionDataModel'
+import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../../src/routes/paths';
 import SessionService from '../../src/services/SessionService'
 import { createApp } from '../ApplicationFactory';
 import {
@@ -85,7 +85,6 @@ describe('AddressToRemoveController', () => {
 
     it('should throw an error if the session doesn’t exist', async () => {
       jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => undefined);
-      const testData = generateTestData();
 
       await request(app)
         .post(ADDRESS_TO_REMOVE_PAGE_URI)
@@ -158,24 +157,24 @@ describe('AddressToRemoveController', () => {
       })
     });
 
-    it('should accept address details without data for Address Line 2', async () => {
+    it('should accept address details without data for Address Line 2, and redirect to the Document Details page', async () => {
 
       const testData = generateTestData();
       testData.line2 = '';
 
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.header.location).toContain(ADDRESS_TO_REMOVE_PAGE_URI);
+        expect(response.header.location).toContain(DOCUMENT_DETAILS_PAGE_URI);
       });
     });
 
-    it('should redirect to the next page if the information provided by the user is valid', async () => {
+    it('should redirect to the Document Details page if the information provided by the user is valid', async () => {
 
       const testData = generateTestData();
 
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.header.location).toContain(ADDRESS_TO_REMOVE_PAGE_URI);
+        expect(response.header.location).toContain(DOCUMENT_DETAILS_PAGE_URI);
       });
     });
 

--- a/test/controllers/DocumentDetailsController.test.ts
+++ b/test/controllers/DocumentDetailsController.test.ts
@@ -1,15 +1,15 @@
 import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
-import {DOCUMENT_DETAILS_PAGE_URI} from '../../src/routes/paths';
-import {
-  expectToHaveErrorMessages,
-  expectToHaveErrorSummaryContaining, expectToHaveInput, expectToHavePopulatedInput,
-  expectToHaveTitle
-} from '../HtmlPatternAssertions'
-import { createApp } from '../ApplicationFactory';
-import SessionService from '../../src/services/SessionService';
 import { DocumentDetails, SuppressionData } from '../../src/models/SuppressionDataModel';
+import {ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI} from '../../src/routes/paths';
+import SessionService from '../../src/services/SessionService';
+import { createApp } from '../ApplicationFactory';
+import {
+  expectToHaveBackButton,
+  expectToHaveErrorMessages, expectToHaveErrorSummaryContaining, expectToHaveInput,
+  expectToHavePopulatedInput, expectToHaveTitle
+} from '../HtmlPatternAssertions'
 
 const expectedTitle: string = 'Document details';
 const missingCompanyNameErrorMessage: string = 'Company name is required';
@@ -32,6 +32,7 @@ describe('DocumentDetailsController', () => {
         .expect(response => {
           expect(response.status).toEqual(StatusCodes.OK);
           expectToHaveTitle(response.text, expectedTitle);
+          expectToHaveBackButton(response.text, ADDRESS_TO_REMOVE_PAGE_URI);
           expectToHaveInput(response.text, 'companyName', 'Company name');
           expectToHaveInput(response.text, 'companyNumber', 'Company number');
           expectToHaveInput(response.text, 'description', 'Document description');
@@ -47,7 +48,7 @@ describe('DocumentDetailsController', () => {
 
       jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => {
         return {
-          documentDetails: documentDetails
+          documentDetails
         } as SuppressionData
       });
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/SR-27

### Change description

This commit links the "Address to Remove" and "Document Details" pages, by implementing forward and backward navigation between the two pages.

**NOTE:** For manual testing, user must submit data on the Applicant Details page before attempting to submit data on the Address to Remove page. This is in line with the expected user journey.

### Work Checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria
