### PR TITLE
feat: Applicant Details <-> Address to Remove transition

### DIFF
--- a/src/controllers/AddressToRemoveController.ts
+++ b/src/controllers/AddressToRemoveController.ts
@@ -2,13 +2,14 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes  } from 'http-status-codes';
 
 import { Address } from '../models/SuppressionDataModel'
-import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
+import { APPLICANT_DETAILS_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
 import SessionService from '../services/SessionService'
 import { ValidationResult } from '../utils/validation/ValidationResult';
 import { FormValidator } from '../validators/FormValidator';
 import { schema as formSchema } from '../validators/schema/AddressToRemoveSchema'
 
 const template = 'address-to-remove';
+const backNavigation = APPLICANT_DETAILS_PAGE_URI;
 
 export class AddressToRemoveController {
 
@@ -16,7 +17,10 @@ export class AddressToRemoveController {
 
   public renderView = (req: Request, res: Response, next: NextFunction) => {
     const session = SessionService.getSuppressionSession(req);
-    res.render(template, { ...session?.addressToRemove });
+    res.render(template, {
+      ...session?.addressToRemove,
+      backNavigation
+    });
   }
 
   public processForm = async (req: Request, res: Response, next: NextFunction) => {
@@ -30,7 +34,8 @@ export class AddressToRemoveController {
       res.status(StatusCodes.UNPROCESSABLE_ENTITY);
       return res.render(template, {
         ...req.body,
-        validationResult
+        validationResult,
+        backNavigation
       });
     } else {
       session.addressToRemove = req.body as Address;

--- a/src/controllers/ApplicantDetailsController.ts
+++ b/src/controllers/ApplicantDetailsController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes  } from 'http-status-codes';
 
 import { ApplicantDetails, SuppressionData } from '../models/SuppressionDataModel'
-import { APPLICANT_DETAILS_PAGE_URI, ROOT_URI } from '../routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, ROOT_URI } from '../routes/paths';
 import SessionService from '../services/SessionService'
 import { ValidationResult } from '../utils/validation/ValidationResult';
 import { FormValidator } from '../validators/FormValidator';
@@ -39,7 +39,7 @@ export class ApplicantDetailsController {
         SessionService.setSuppressionSession(req, session);
       }
 
-      res.redirect(APPLICANT_DETAILS_PAGE_URI);
+      res.redirect(ADDRESS_TO_REMOVE_PAGE_URI);
     }
   };
 }

--- a/src/views/address-to-remove.njk
+++ b/src/views/address-to-remove.njk
@@ -4,9 +4,19 @@
 {% from 'govuk/components/input/macro.njk'         import govukInput %}
 {% from 'govuk/components/button/macro.njk'        import govukButton %}
 {% from "govuk/components/fieldset/macro.njk"      import govukFieldset %}
+{% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
 
 {% block pageTitle %}
   Address details
+{% endblock %}
+
+{% block backLink %}
+  {{
+    govukBackLink({
+      text: 'Back',
+      href: backNavigation
+    })
+  }}
 {% endblock %}
 
 {% block content %}

--- a/test/controllers/AddressToRemoveController.test.ts
+++ b/test/controllers/AddressToRemoveController.test.ts
@@ -2,10 +2,11 @@ import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
 import { Address, SuppressionData } from '../../src/models/SuppressionDataModel'
-import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../../src/routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, APPLICANT_DETAILS_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../../src/routes/paths';
 import SessionService from '../../src/services/SessionService'
 import { createApp } from '../ApplicationFactory';
 import {
+  expectToHaveBackButton,
   expectToHaveErrorMessages,
   expectToHaveErrorSummaryContaining,
   expectToHaveInput,
@@ -39,6 +40,7 @@ describe('AddressToRemoveController', () => {
       await request(app).get(ADDRESS_TO_REMOVE_PAGE_URI).expect(response => {
         expect(response.status).toEqual(StatusCodes.OK);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveInput(
           response.text,
           'line1',
@@ -57,6 +59,7 @@ describe('AddressToRemoveController', () => {
       await request(app).get(ADDRESS_TO_REMOVE_PAGE_URI).expect(response => {
         expect(response.status).toEqual(StatusCodes.OK);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHavePopulatedInput(response.text, 'line1', '1 Test Street');
         expectToHavePopulatedInput(response.text, 'town', 'Test Town');
         expectToHavePopulatedInput(response.text, 'county', 'Test Midlands');
@@ -96,6 +99,7 @@ describe('AddressToRemoveController', () => {
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).expect(response => {
         expect(response.status).toEqual(StatusCodes.UNPROCESSABLE_ENTITY);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveErrorSummaryContaining(response.text, [
           addressLine1ErrorMessage, townOrCityErrorMessage, countyErrorMessage, postcodeErrorMessage
         ]);
@@ -113,6 +117,7 @@ describe('AddressToRemoveController', () => {
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.UNPROCESSABLE_ENTITY);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveErrorSummaryContaining(response.text, [addressLine1ErrorMessage]);
         expectToHaveErrorMessages(response.text, [addressLine1ErrorMessage]);
       })
@@ -126,6 +131,7 @@ describe('AddressToRemoveController', () => {
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.UNPROCESSABLE_ENTITY);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveErrorSummaryContaining(response.text, [townOrCityErrorMessage]);
         expectToHaveErrorMessages(response.text, [townOrCityErrorMessage]);
       })
@@ -139,6 +145,7 @@ describe('AddressToRemoveController', () => {
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.UNPROCESSABLE_ENTITY);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveErrorSummaryContaining(response.text, [countyErrorMessage]);
         expectToHaveErrorMessages(response.text, [countyErrorMessage]);
       })
@@ -152,6 +159,7 @@ describe('AddressToRemoveController', () => {
       await request(app).post(ADDRESS_TO_REMOVE_PAGE_URI).send(testData).expect(response => {
         expect(response.status).toEqual(StatusCodes.UNPROCESSABLE_ENTITY);
         expectToHaveTitle(response.text, pageTitle);
+        expectToHaveBackButton(response.text, APPLICANT_DETAILS_PAGE_URI);
         expectToHaveErrorSummaryContaining(response.text, [postcodeErrorMessage]);
         expectToHaveErrorMessages(response.text, [postcodeErrorMessage]);
       })

--- a/test/controllers/ApplicantDetailsController.test.ts
+++ b/test/controllers/ApplicantDetailsController.test.ts
@@ -1,13 +1,13 @@
 import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
-import { APPLICANT_DETAILS_PAGE_URI, ROOT_URI } from '../../src/routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, APPLICANT_DETAILS_PAGE_URI, ROOT_URI } from '../../src/routes/paths';
 import { createApp } from '../ApplicationFactory';
 import {
   expectToHaveBackButton,
   expectToHaveErrorMessages,
   expectToHaveErrorSummaryContaining,
-  expectToHaveInput, expectToHaveLink,
+  expectToHaveInput,
   expectToHaveTitle
 } from '../HtmlPatternAssertions'
 
@@ -91,7 +91,7 @@ describe('ApplicantDetailsController', () => {
         emailAddress: 'test@example.com'
       }).expect(response => {
         expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
-        expect(response.header.location).toContain(APPLICANT_DETAILS_PAGE_URI);
+        expect(response.header.location).toContain(ADDRESS_TO_REMOVE_PAGE_URI);
       });
     });
   });


### PR DESCRIPTION
### JIRA

[Jira Ticket](https://companieshouse.atlassian.net/browse/SR-86)

### Change Description

This commit links the "Applicant Details" and "Address to Remove" pages, by implementing forward and backward navigation between the two pages.

### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria