### PR TITLE
chore: Abstract date input into reusable nunjucks macro

### DIFF
--- a/src/views/components/date-input.njk
+++ b/src/views/components/date-input.njk
@@ -1,6 +1,6 @@
 {% from 'govuk/components/date-input/macro.njk' import govukDateInput %}
 
-{% macro date_input(idPrefix, labelText, validationResult, hintText) %}
+{% macro dateInput(params) %}
   {% set classes_day = 'govuk-input--width-2' %}
   {% set classes_month = 'govuk-input--width-2' %}
   {% set classes_year = 'govuk-input--width-4' %}
@@ -8,24 +8,24 @@
   {% set dateErrorMessage = false %}
   {% set hasDateError = false %}
 
-  {% if validationResult and validationResult.errors.length > 0 %}
+  {% if params.validationResult and params.validationResult.errors.length > 0 %}
 
-    {% if validationResult.getErrorForField('day') %}
+    {% if params.validationResult.getErrorForField('day') %}
       {% set classes_day = classes_day + ' govuk-input--error' %}
       {% set hasDateError = true %}
     {% endif %}
 
-    {% if validationResult.getErrorForField('month') %}
+    {% if params.validationResult.getErrorForField('month') %}
       {% set classes_month = classes_month + ' govuk-input--error' %}
       {% set hasDateError = true %}
     {% endif %}
 
-    {% if validationResult.getErrorForField('year') %}
+    {% if params.validationResult.getErrorForField('year') %}
       {% set classes_year = classes_year + ' govuk-input--error' %}
       {% set hasDateError = true %}
     {% endif %}
 
-    {% if validationResult.getErrorForField('date') %}
+    {% if params.validationResult.getErrorForField('date') %}
       {% set classes_day = classes_day + ' govuk-input--error' %}
       {% set classes_month = classes_month + ' govuk-input--error' %}
       {% set classes_year = classes_year + ' govuk-input--error' %}
@@ -36,7 +36,7 @@
   {% if hasDateError %}
     {% set errorMessages %}
       <ul style="padding: 0;list-style-type: none;">
-        {% for error in validationResult.errors %}
+        {% for error in params.validationResult.errors %}
           {% if error.field in ['day', 'month', 'year', 'date'] %}
             <li>
               {{ error.text }}
@@ -53,22 +53,22 @@
 
   {{
     govukDateInput ({
-      id: idPrefix + '-date',
+      id: params.idPrefix + '-date',
       fieldset: {
         legend: {
-          text: labelText,
+          text: params.labelText,
           isPageHeading: false,
           classes: 'govuk-fieldset__legend--s'
         }
       },
       hint: {
-        text: hintText
+        text: params.hintText
       },
       errorMessage: dateErrorMessage,
       items: [
         {
           classes: classes_day,
-          id: idPrefix + '-day',
+          id: params.idPrefix + '-day',
           label: 'Day',
           name: 'day',
           value: day,
@@ -76,7 +76,7 @@
         },
         {
           classes: classes_month,
-          id: idPrefix + '-month',
+          id: params.idPrefix + '-month',
           label: 'Month',
           name: 'month',
           value: month,
@@ -84,7 +84,7 @@
         },
         {
           classes: classes_year,
-          id: idPrefix + '-year',
+          id: params.idPrefix + '-year',
           label: 'Year',
           name: 'year',
           value: year,

--- a/src/views/components/date-input.njk
+++ b/src/views/components/date-input.njk
@@ -1,0 +1,97 @@
+{% from 'govuk/components/date-input/macro.njk' import govukDateInput %}
+
+{% macro date_input(idPrefix, labelText, validationResult, hintText) %}
+  {% set classes_day = 'govuk-input--width-2' %}
+  {% set classes_month = 'govuk-input--width-2' %}
+  {% set classes_year = 'govuk-input--width-4' %}
+
+  {% set dateErrorMessage = false %}
+  {% set hasDateError = false %}
+
+  {% if validationResult and validationResult.errors.length > 0 %}
+
+    {% if validationResult.getErrorForField('day') %}
+      {% set classes_day = classes_day + ' govuk-input--error' %}
+      {% set hasDateError = true %}
+    {% endif %}
+
+    {% if validationResult.getErrorForField('month') %}
+      {% set classes_month = classes_month + ' govuk-input--error' %}
+      {% set hasDateError = true %}
+    {% endif %}
+
+    {% if validationResult.getErrorForField('year') %}
+      {% set classes_year = classes_year + ' govuk-input--error' %}
+      {% set hasDateError = true %}
+    {% endif %}
+
+    {% if validationResult.getErrorForField('date') %}
+      {% set classes_day = classes_day + ' govuk-input--error' %}
+      {% set classes_month = classes_month + ' govuk-input--error' %}
+      {% set classes_year = classes_year + ' govuk-input--error' %}
+      {% set hasDateError = true %}
+    {% endif %}
+  {% endif %}
+
+  {% if hasDateError %}
+    {% set errorMessages %}
+      <ul style="padding: 0;list-style-type: none;">
+        {% for error in validationResult.errors %}
+          {% if error.field in ['day', 'month', 'year', 'date'] %}
+            <li>
+              {{ error.text }}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% endset %}
+  {% endif %}
+
+  {% if errorMessages %}
+    {% set dateErrorMessage = { html: errorMessages } %}
+  {% endif %}
+
+  {{
+    govukDateInput ({
+      id: idPrefix + '-date',
+      fieldset: {
+        legend: {
+          text: labelText,
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--s'
+        }
+      },
+      hint: {
+        text: hintText
+      },
+      errorMessage: dateErrorMessage,
+      items: [
+        {
+          classes: classes_day,
+          id: idPrefix + '-day',
+          label: 'Day',
+          name: 'day',
+          value: day,
+          autocomplete: 'off'
+        },
+        {
+          classes: classes_month,
+          id: idPrefix + '-month',
+          label: 'Month',
+          name: 'month',
+          value: month,
+          autocomplete: 'off'
+        },
+        {
+          classes: classes_year,
+          id: idPrefix + '-year',
+          label: 'Year',
+          name: 'year',
+          value: year,
+          autocomplete: 'off'
+        }
+      ]
+    })
+  }}
+
+{% endmacro %}

--- a/src/views/components/date-input.njk
+++ b/src/views/components/date-input.njk
@@ -71,7 +71,7 @@
           id: params.idPrefix + '-day',
           label: 'Day',
           name: 'day',
-          value: day,
+          value: params.values.day,
           autocomplete: 'off'
         },
         {
@@ -79,7 +79,7 @@
           id: params.idPrefix + '-month',
           label: 'Month',
           name: 'month',
-          value: month,
+          value: params.values.month,
           autocomplete: 'off'
         },
         {
@@ -87,7 +87,7 @@
           id: params.idPrefix + '-year',
           label: 'Year',
           name: 'year',
-          value: year,
+          value: params.values.year,
           autocomplete: 'off'
         }
       ]

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -81,7 +81,7 @@
               isPageHeading: false
             },
             hint: {
-              text: 'Tell us the name and description of the document you want to remove your home address from. For example, CH01 - Director’s details changed for Mr John Smith on 2 January 2020'
+              text: 'Tell us the name and description of the document you want to remove your home address from. For example, CH01 - Director\'s details changed for Mr John Smith on 2 January 2020'
             },
             errorMessage: validationResult.getErrorForField('description') if validationResult,
             classes: 'govuk-input--width-20',

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -4,7 +4,7 @@
 {% from 'govuk/components/input/macro.njk'         import govukInput %}
 {% from 'govuk/components/button/macro.njk'        import govukButton %}
 {% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
-{% from 'components/date-input.njk'                import date_input %}
+{% from 'components/date-input.njk'                import dateInput %}
 
 {% block pageTitle %}
   Document details
@@ -81,7 +81,7 @@
               isPageHeading: false
             },
             hint: {
-              text: 'Tell us the name and description of the document you want to remove your home address from. For example, CH01 - Director\'s details changed for Mr John Smith on 2 January 2020'
+              text: 'Tell us the name and description of the document you want to remove your home address from. For example, CH01 - Director’s details changed for Mr John Smith on 2 January 2020'
             },
             errorMessage: validationResult.getErrorForField('description') if validationResult,
             classes: 'govuk-input--width-20',
@@ -92,7 +92,12 @@
           })
         }}
         {{
-          date_input('document', 'Document date', validationResult, 'For example, 12 11 2007')
+          dateInput({
+            idPrefix: 'document',
+            labelText: 'Document date',
+            hintText: 'For example, 12 11 2007',
+            validationResult: validationResult
+          })
         }}
         {{
           govukButton({

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -96,7 +96,12 @@
             idPrefix: 'document',
             labelText: 'Document date',
             hintText: 'For example, 12 11 2007',
-            validationResult: validationResult
+            validationResult: validationResult,
+            values: {
+              day: day,
+              month: month,
+              year: year
+            }
           })
         }}
         {{

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -2,9 +2,9 @@
 
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/input/macro.njk'         import govukInput %}
-{% from 'govuk/components/date-input/macro.njk'    import govukDateInput %}
 {% from 'govuk/components/button/macro.njk'        import govukButton %}
 {% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
+{% from 'components/date-input.njk'                import date_input %}
 
 {% block pageTitle %}
   Document details
@@ -29,55 +29,6 @@
           errorList: validationResult.errors
         }) if validationResult and validationResult.errors.length > 0
       }}
-
-      {% set classes_day = 'govuk-input--width-2' %}
-      {% set classes_month = 'govuk-input--width-2' %}
-      {% set classes_year = 'govuk-input--width-4' %}
-      {% set documentDateErrorMessage = false %}
-      {% set hasDateError = false %}
-
-      {% if validationResult and validationResult.errors.length > 0 %}
-
-        {% if validationResult.getErrorForField('day') %}
-          {% set classes_day = classes_day + ' govuk-input--error' %}
-          {% set hasDateError = true %}
-        {% endif %}
-        {% if validationResult.getErrorForField('month') %}
-          {% set classes_month = classes_month + ' govuk-input--error' %}
-          {% set hasDateError = true %}
-        {% endif %}
-         {% if validationResult.getErrorForField('year') %}
-          {% set classes_year = classes_year + ' govuk-input--error' %}
-          {% set hasDateError = true %}
-        {% endif %}
-        {% if validationResult.getErrorForField('date') %}
-          {% set classes_day = classes_day + ' govuk-input--error' %}
-          {% set classes_month = classes_month + ' govuk-input--error' %}
-          {% set classes_year = classes_year + ' govuk-input--error' %}
-          {% set hasDateError = true %}
-        {% endif %}
-
-        {% if hasDateError %}
-          {% set errorMessages %}
-            <ul style="padding: 0;list-style-type: none;">
-              {% for error in validationResult.errors %}
-                {% if error.field in ['day', 'month', 'year', 'date'] %}
-                  <li>
-                    {{ error.text }}
-                  </li>
-                {% endif %}
-              {% endfor %}
-            </ul>
-          {% endset %}
-        {% endif %}
-
-        {% if errorMessages %}
-          {% set documentDateErrorMessage = {
-            html: errorMessages
-            }
-          %}
-        {% endif %}
-      {% endif %}
 
       <h1 class="govuk-heading-l">
         What are the document details?
@@ -141,46 +92,7 @@
           })
         }}
         {{
-          govukDateInput ({
-            id: 'document-date',
-            fieldset: {
-              legend: {
-                text: 'Document date',
-                isPageHeading: false,
-                classes: 'govuk-fieldset__legend--s'
-              }
-            },
-            hint: {
-              text: 'For example, 12 11 2007'
-            },
-            errorMessage: documentDateErrorMessage,
-            items: [
-              {
-                classes: classes_day,
-                id: 'doc-day',
-                label: 'Day',
-                name: 'day',
-                value: day,
-                autocomplete: 'off'
-              },
-              {
-                classes: classes_month,
-                id: 'doc-month',
-                label: 'Month',
-                name: 'month',
-                value: month,
-                autocomplete: 'off'
-              },
-              {
-                classes: classes_year,
-                id: 'doc-year',
-                label: 'Year',
-                name: 'year',
-                value: year,
-                autocomplete: 'off'
-              }
-            ]
-          })
+          date_input('document', 'Document date', validationResult, 'For example, 12 11 2007')
         }}
         {{
           govukButton({


### PR DESCRIPTION
### Change Description

This commit abstracts the data input and error message logic into a reusable macro, so that it can be used on other pages without code duplication.