### PR TITLE
chore: use auth token for communicating to Suppression API

### DIFF
--- a/src/modules/config-handler/ConfigValidation.schema.ts
+++ b/src/modules/config-handler/ConfigValidation.schema.ts
@@ -11,8 +11,7 @@ export const configValidationSchema = Joi.object({
   COOKIE_SECRET: Joi.string().required(),
   CACHE_SERVER: Joi.string().required(),
   COOKIE_EXPIRATION_IN_SECONDS: Joi.string().required(),
-  DOCUMENT_AMENDMENT_FEE: Joi.number().required(),
-  CHS_API_KEY: Joi.string().required()
+  DOCUMENT_AMENDMENT_FEE: Joi.number().required()
 }).options({
   allowUnknown: true
 });

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -14,7 +14,7 @@ export default class SessionService {
   }
 
   static getAccessToken(req: Request): string {
-    const signInInfo = req.session!.get<ISignInInfo>(SessionKey.SignInInfo)!
+    const signInInfo = req.session!.get<ISignInInfo>(SessionKey.SignInInfo)!;
     return signInInfo.access_token!.access_token!
   }
 }

--- a/src/services/suppression/SuppressionService.ts
+++ b/src/services/suppression/SuppressionService.ts
@@ -9,17 +9,17 @@ export class SuppressionService {
     this.uri = uri;
   }
 
-  public async save(suppression: SuppressionData, apiKey: string): Promise<string> {
+  public async save(suppression: SuppressionData, accessToken: string): Promise<string> {
 
     this.checkArgumentOrThrow(suppression, 'Suppression data is missing');
-    this.checkArgumentOrThrow(apiKey, 'Key is missing');
+    this.checkArgumentOrThrow(accessToken, 'Access token is missing');
 
     const uri: string = `${this.uri}/suppressions`;
 
     console.log(`${SuppressionService.name} - Making a POST request to ${uri}`);
 
     return await axios
-      .post(uri, suppression, {headers: this.getHeaders(apiKey)})
+      .post(uri, suppression, {headers: this.getHeaders(accessToken)})
       .then((response: AxiosResponse<string>) => {
         if (response.status === StatusCodes.CREATED && response.headers.location) {
           console.log(`${SuppressionService.name} - save: created resource ${response.data} - ${response.headers.location}`);
@@ -54,11 +54,11 @@ export class SuppressionService {
     }
   }
 
-  private getHeaders(apiKey: string): AxiosRequestConfig['headers'] {
+  private getHeaders(accessToken: string): AxiosRequestConfig['headers'] {
     return {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
-      'Authorization': apiKey
+      'Authorization': 'Bearer ' + accessToken
     };
   }
 }

--- a/test/services/suppression/SuppressionService.test.ts
+++ b/test/services/suppression/SuppressionService.test.ts
@@ -12,7 +12,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('SuppressionService', () => {
 
-  const mockApiKey: string = 'key';
+  const mockAccessToken: string = 'token';
   const mockGeneratedReference: string = '123123';
   const mockSuppressionsUri: string = '/suppressions';
 
@@ -25,7 +25,7 @@ describe('SuppressionService', () => {
     it('should throw an error when suppression not defined', async() => {
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save(undefined as any, mockApiKey).catch((err) => {
+      await suppressionService.save(undefined as any, mockAccessToken).catch((err) => {
         expect(err).toEqual(Error('Suppression data is missing'))
       })
     });
@@ -34,7 +34,7 @@ describe('SuppressionService', () => {
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
       await suppressionService.save({} as SuppressionData, undefined as any).catch((err) => {
-        expect(err).toEqual(Error('Key is missing'))
+        expect(err).toEqual(Error('Access token is missing'))
       });
     });
 
@@ -50,7 +50,7 @@ describe('SuppressionService', () => {
 
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save({} as SuppressionData, mockApiKey).then((response: string) => {
+      await suppressionService.save({} as SuppressionData, mockAccessToken).then((response: string) => {
         expect(response).toEqual(mockGeneratedReference)
       });
 
@@ -64,7 +64,7 @@ describe('SuppressionService', () => {
 
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save({} as SuppressionData, mockApiKey).catch((err) => {
+      await suppressionService.save({} as SuppressionData, mockAccessToken).catch((err) => {
         expect(err).toEqual(new Error('save suppression failed with message: Could not create suppression resource'));
       })
 
@@ -78,7 +78,7 @@ describe('SuppressionService', () => {
 
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save({} as SuppressionData, mockApiKey).catch((err) => {
+      await suppressionService.save({} as SuppressionData, mockAccessToken).catch((err) => {
         expect(err).toEqual(new SuppressionUnprocessableEntityError('save suppression on invalid suppression data'));
       })
     });
@@ -91,7 +91,7 @@ describe('SuppressionService', () => {
 
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save({} as SuppressionData, mockApiKey).catch((err) => {
+      await suppressionService.save({} as SuppressionData, mockAccessToken).catch((err) => {
         expect(err).toEqual(new SuppressionUnauthorisedError('save suppression unauthorised'));
       })
     });
@@ -104,7 +104,7 @@ describe('SuppressionService', () => {
 
       const suppressionService = new SuppressionService(mockSuppressionsUri);
 
-      await suppressionService.save({} as SuppressionData, mockApiKey).catch((err) => {
+      await suppressionService.save({} as SuppressionData, mockAccessToken).catch((err) => {
         expect(err).toEqual(new Error('save suppression failed. API not found'));
       })
 


### PR DESCRIPTION
### JIRA

[Jira Ticket](https://companieshouse.atlassian.net/browse/SR-91)

### Change Description

Removing the use of the API key, and instead using the access token from sign in to get through ERIC and communicate with our API.

Requires changes to docker env in: https://github.com/companieshouse/docker-chs-development/pull/50

### Page Screenshot



### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
