### PR TITLE
feat: Document Details <-> Service (Replacement) Address transition

### DIFF
--- a/src/controllers/DocumentDetailsController.ts
+++ b/src/controllers/DocumentDetailsController.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import moment from 'moment';
 
 import { DocumentDetails, SuppressionData } from '../models/SuppressionDataModel';
-import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI } from '../routes/paths';
+import { ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI, SERVICE_ADDRESS_PAGE_URI } from '../routes/paths';
 import SessionService from '../services/session/SessionService';
 import { FormWithDateValidator } from '../validators/FormWithDateValidator';
 import { schema } from '../validators/schema/DocumentDetailsSchema';
@@ -51,7 +51,7 @@ export class DocumentDetailsController {
     } as DocumentDetails;
 
     SessionService.setSuppressionSession(req, suppression);
-    res.redirect(DOCUMENT_DETAILS_PAGE_URI);
+    res.redirect(SERVICE_ADDRESS_PAGE_URI);
   }
 
   private getDocumentDetails(suppression: SuppressionData | undefined): any {

--- a/src/controllers/ServiceAddressController.ts
+++ b/src/controllers/ServiceAddressController.ts
@@ -2,17 +2,19 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes  } from 'http-status-codes';
 
 import { Address } from '../models/SuppressionDataModel'
-import { SERVICE_ADDRESS_PAGE_URI } from '../routes/paths';
+import { DOCUMENT_DETAILS_PAGE_URI, SERVICE_ADDRESS_PAGE_URI } from '../routes/paths';
 import SessionService from '../services/session/SessionService'
 
 const template = 'service-address';
+const backNavigation = DOCUMENT_DETAILS_PAGE_URI;
 
 export class ServiceAddressController {
 
   public renderView = (req: Request, res: Response, next: NextFunction) => {
     const session = SessionService.getSuppressionSession(req);
     res.render(template, {
-      ...session?.serviceAddress
+      ...session?.serviceAddress,
+      backNavigation
     });
   }
 

--- a/test/controllers/DocumentDetailsController.test.ts
+++ b/test/controllers/DocumentDetailsController.test.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
 import { DocumentDetails, SuppressionData } from '../../src/models/SuppressionDataModel';
-import {ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI} from '../../src/routes/paths';
+import {ADDRESS_TO_REMOVE_PAGE_URI, DOCUMENT_DETAILS_PAGE_URI, SERVICE_ADDRESS_PAGE_URI} from '../../src/routes/paths';
 import SessionService from '../../src/services/session/SessionService';
 import { createApp } from '../ApplicationFactory';
 import {
@@ -81,7 +81,7 @@ describe('DocumentDetailsController', () => {
 
   describe('on POST', () => {
 
-    it('should return 302 response when valid data was submitted', async () => {
+    it('should redirect to the Service (Replacement) Address page when valid data was submitted', async () => {
 
       const app = createApp();
 
@@ -99,7 +99,7 @@ describe('DocumentDetailsController', () => {
         .send(documentDetails)
         .expect(response => {
           expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
-          expect(response.header.location).toEqual(DOCUMENT_DETAILS_PAGE_URI)
+          expect(response.header.location).toEqual(SERVICE_ADDRESS_PAGE_URI)
         });
     });
 

--- a/test/controllers/DocumentDetailsController.test.ts
+++ b/test/controllers/DocumentDetailsController.test.ts
@@ -81,7 +81,7 @@ describe('DocumentDetailsController', () => {
 
   describe('on POST', () => {
 
-    it('should redirect to the Service (Replacement) Address page when valid data was submitted', async () => {
+    it('should redirect to the Service Address page when valid data was submitted', async () => {
 
       const app = createApp();
 

--- a/test/controllers/ServiceAddressController.test.ts
+++ b/test/controllers/ServiceAddressController.test.ts
@@ -3,11 +3,13 @@ import request from 'supertest';
 
 import { Address, SuppressionData } from '../../src/models/SuppressionDataModel'
 import {
+  DOCUMENT_DETAILS_PAGE_URI,
   SERVICE_ADDRESS_PAGE_URI
 } from '../../src/routes/paths';
 import SessionService from '../../src/services/session/SessionService'
 import { createApp } from '../ApplicationFactory';
 import {
+  expectToHaveBackButton,
   expectToHaveInput,
   expectToHavePopulatedInput,
   expectToHaveTitle
@@ -45,6 +47,7 @@ describe('ServiceAddressController', () => {
         .expect(response => {
           expect(response.status).toEqual(StatusCodes.OK);
           expectToHaveTitle(response.text, pageTitle);
+          expectToHaveBackButton(response.text, DOCUMENT_DETAILS_PAGE_URI);
           expectToHaveInput(
             response.text,
             'line1',
@@ -75,6 +78,7 @@ describe('ServiceAddressController', () => {
         .expect(response => {
           expect(response.status).toEqual(StatusCodes.OK);
           expectToHaveTitle(response.text, pageTitle);
+          expectToHaveBackButton(response.text, DOCUMENT_DETAILS_PAGE_URI);
           expectToHavePopulatedInput(response.text, 'line1', '1 Main Street');
           expectToHavePopulatedInput(response.text, 'line2', 'Selly Oak');
           expectToHavePopulatedInput(response.text, 'town', 'Cardiff');


### PR DESCRIPTION
### JIRA

[Jira Ticket](https://companieshouse.atlassian.net/browse/SR-105)

### Change Description

This commit links the "Document Details" and "Service Address" pages, by implementing forward and backward navigation between the two pages.

### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%