### PR TITLE
fix: Move healthcheck endpoint to root

### DIFF
--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -7,4 +7,4 @@ export const SERVICE_ADDRESS_PAGE_URI = `${ROOT_URI}/service-address`;
 export const PAYMENT_REVIEW_PAGE_URI = `${ROOT_URI}/payment-review`;
 export const CONFIRMATION_PAGE_URI = `${ROOT_URI}/confirmation`;
 
-export const HEALTHCHECK_URI = `${ROOT_URI}/healthcheck`;
+export const HEALTHCHECK_URI = `/healthcheck`;


### PR DESCRIPTION
### Change Description

As per the style guidance for healthcheck endpoints, the healthcheck endpoint has been moved:

`/suppress-my-details/healthcheck` -> `/healthcheck`