### PR TITLE
fix: Incorrect button label on Check Your Answers page

### DIFF
--- a/src/views/check-submission.njk
+++ b/src/views/check-submission.njk
@@ -136,7 +136,7 @@
       <form method="post">
         {{
           govukButton({
-            text: 'Confirm and submit',
+            text: 'Accept and submit',
             attributes: {
               id: 'submit'
             }

--- a/test/controllers/CheckSubmissionController.test.ts
+++ b/test/controllers/CheckSubmissionController.test.ts
@@ -55,7 +55,7 @@ describe('CheckSubmissionController', () => {
             'What address do you want to replace your home address with\\?',
             '1 Main Street<br>Cardiff<br>Cardiff<br>CF14 3UZ<br>United Kingdom');
           expectToHaveTableRow(response.text, 'Email address', 'test@example.com');
-          expectToHaveButton(response.text, 'Confirm and submit');
+          expectToHaveButton(response.text, 'Accept and submit');
         });
     });
 


### PR DESCRIPTION
### JIRA

[Jira Ticket](https://companieshouse.atlassian.net/browse/SR-40)

### Change Description

Confusion between screenshot on Jira Ticket and Prototype V4 led to muddling of the label on the Check Your Answers page's button. This commit rectifies the issue.

### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%