### PR TITLE
fix: broken links in Validation Error summaries

### DIFF
--- a/src/views/address-to-remove.njk
+++ b/src/views/address-to-remove.njk
@@ -47,7 +47,7 @@
                 html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
               },
               errorMessage: validationResult.getErrorForField('line1') if validationResult,
-              id: 'address-line-1',
+              id: 'line1',
               name: 'line1',
               value: line1,
               autocomplete: 'address-line1'
@@ -58,7 +58,7 @@
               label: {
                 html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
               },
-              id: 'address-line-2',
+              id: 'line2',
               name: 'line2',
               value: line2,
               autocomplete: 'address-line2'
@@ -71,7 +71,7 @@
               },
               errorMessage: validationResult.getErrorForField('town') if validationResult,
               classes: 'govuk-!-width-two-thirds',
-              id: 'address-town',
+              id: 'town',
               name: 'town',
               value: town,
               autocomplete: 'address-level2'
@@ -84,7 +84,7 @@
               },
               errorMessage: validationResult.getErrorForField('county') if validationResult,
               classes: 'govuk-!-width-two-thirds',
-              id: 'address-County',
+              id: 'county',
               name: 'county',
               value: county
             })
@@ -96,7 +96,7 @@
               },
               errorMessage: validationResult.getErrorForField('postcode') if validationResult,
               classes: 'govuk-input--width-10',
-              id: 'address-postcode',
+              id: 'postcode',
               name: 'postcode',
               value: postcode,
               autocomplete: 'postal-code'
@@ -109,7 +109,7 @@
             },
             errorMessage: validationResult.getErrorForField('country') if validationResult,
             classes: 'govuk-input--width-10',
-            id: 'address-country',
+            id: 'country',
             name: 'country',
             value: country,
             autocomplete: 'address-country'

--- a/src/views/applicant-details.njk
+++ b/src/views/applicant-details.njk
@@ -66,7 +66,7 @@
 
         {{
           govukRadios({
-            idPrefix: 'previous-name-conditional',
+            idPrefix: 'has-previous-name',
             name: 'hasPreviousName',
             fieldset: {
               legend: {

--- a/src/views/document-details.njk
+++ b/src/views/document-details.njk
@@ -85,7 +85,7 @@
             },
             errorMessage: validationResult.getErrorForField('description') if validationResult,
             classes: 'govuk-input--width-20',
-            id: 'document-description',
+            id: 'description',
             name: 'description',
             value: description,
             autocomplete: 'description'


### PR DESCRIPTION
### JIRA

[Web: Fix broken links in Validation Error summaries](https://companieshouse.atlassian.net/browse/SR-110)

### Change Description

When input validation on a field fails, the intended behaviour of the Error Summary is to display a list of the errors on that page, with each error hyperlinked to the appropriate field. Currently, many of these links are broken.

**The bug is caused by a mismatch between each input's `id` and `name` attributes.**

### Page Screenshot



### Work Checklist

- [ ] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
