### PR TITLE
feat: Manage user return from Payment journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2291,8 +2291,8 @@
       }
     },
     "ch-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0262388eef8a6f749638064b0c10ba42957e5386",
-      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git",
+      "version": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#6fd9347ce6e324d724a34bb32c1cc37ca4c5bd52",
+      "from": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#6fd9347c",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#4.0.0",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git",
+    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#6fd9347c",
     "connect-redis": "^5.0.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
@@ -33,8 +33,8 @@
     "joi": "^17.2.1",
     "moment": "^2.27.0",
     "nunjucks": "^3.2.2",
-    "web-security-node": "git+ssh://git@github.com/companieshouse/web-security-node.git#0.1.1",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "web-security-node": "git+ssh://git@github.com/companieshouse/web-security-node.git#0.1.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#4.0.0",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#6fd9347c",
+    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/api-sdk-node.git",
     "connect-redis": "^5.0.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/src/controllers/PaymentCallbackController.ts
+++ b/src/controllers/PaymentCallbackController.ts
@@ -1,0 +1,59 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { PaymentStatus } from '../models/PaymentStatus';
+import { SuppressionData } from '../models/SuppressionDataModel';
+import { CONFIRMATION_PAGE_URI, PAYMENT_REVIEW_PAGE_URI } from '../routes/paths';
+import { PaymentService } from '../services/payment/PaymentService';
+import SessionService from '../services/session/SessionService';
+
+export class PaymentCallbackController {
+
+  constructor(private readonly paymentService: PaymentService) {
+    this.paymentService = paymentService;
+  }
+
+  public checkPaymentStatus = async (req: Request, res: Response, next: NextFunction) => {
+
+    const state = req.query.state;
+    const status = req.query.status;
+    const reference = req.query.ref;
+    if (!(state && status && reference)) {
+      return next(new Error(`${PaymentCallbackController.name} - received invalid arguments`));
+    }
+
+    const statusIsValid: boolean = Object.values(PaymentStatus).includes(status as PaymentStatus)
+    if (!statusIsValid) {
+      return next(new Error(`${PaymentCallbackController.name} - received invalid payment status`));
+    }
+
+    const suppressionData: SuppressionData | undefined = SessionService.getSuppressionSession(req);
+    if (!suppressionData) {
+      return next(new Error(`${PaymentCallbackController.name} - session expected but none found`));
+    }
+
+    const expectedPaymentStateUUID = suppressionData.paymentDetails.stateUUID;
+    if (state !== expectedPaymentStateUUID) {
+      return next(new Error(`${PaymentCallbackController.name} - payment state mismatch`));
+    }
+
+    let redirectURI: string;
+    if (status === PaymentStatus.PAID) {
+      const paymentResourceUri = suppressionData.paymentDetails.resourceUri;
+      const accessToken: string =  SessionService.getAccessToken(req);
+      const verifiedStatus = await this.paymentService.getPaymentStatus(paymentResourceUri, accessToken);
+      if (verifiedStatus === PaymentStatus.PAID) {
+        redirectURI = CONFIRMATION_PAGE_URI;
+      } else {
+        console.log(`${PaymentCallbackController.name} - WARN: Could not verify user-reported payment status. Mitigating.`);
+        redirectURI = PAYMENT_REVIEW_PAGE_URI;
+      }
+    } else {
+      redirectURI = PAYMENT_REVIEW_PAGE_URI;
+    }
+
+    suppressionData.paymentDetails.status = status as PaymentStatus;
+    SessionService.setSuppressionSession(req, suppressionData);
+
+    return res.redirect(redirectURI);
+  }
+}

--- a/src/controllers/PaymentCallbackController.ts
+++ b/src/controllers/PaymentCallbackController.ts
@@ -14,9 +14,9 @@ export class PaymentCallbackController {
 
   public checkPaymentStatus = async (req: Request, res: Response, next: NextFunction) => {
 
-    const state = req.query.state;
-    const status = req.query.status;
-    const reference = req.query.ref;
+    const state: string = req.query.state as string;
+    const status: PaymentStatus = req.query.status as PaymentStatus;
+    const reference: string = req.query.ref as string;
     if (!(state && status && reference)) {
       return next(new Error(`${PaymentCallbackController.name} - received invalid arguments`));
     }
@@ -31,16 +31,16 @@ export class PaymentCallbackController {
       return next(new Error(`${PaymentCallbackController.name} - session expected but none found`));
     }
 
-    const expectedPaymentStateUUID = suppressionData.paymentDetails.stateUUID;
+    const expectedPaymentStateUUID: string = suppressionData.paymentDetails.stateUUID;
     if (state !== expectedPaymentStateUUID) {
       return next(new Error(`${PaymentCallbackController.name} - payment state mismatch`));
     }
 
     let redirectURI: string;
     if (status === PaymentStatus.PAID) {
-      const paymentResourceUri = suppressionData.paymentDetails.resourceUri;
+      const paymentResourceUri: string = suppressionData.paymentDetails.resourceUri;
       const accessToken: string =  SessionService.getAccessToken(req);
-      const verifiedStatus = await this.paymentService.getPaymentStatus(paymentResourceUri, accessToken);
+      const verifiedStatus: PaymentStatus = await this.paymentService.getPaymentStatus(paymentResourceUri, accessToken);
       if (verifiedStatus === PaymentStatus.PAID) {
         redirectURI = CONFIRMATION_PAGE_URI;
       } else {
@@ -51,7 +51,7 @@ export class PaymentCallbackController {
       redirectURI = PAYMENT_REVIEW_PAGE_URI;
     }
 
-    suppressionData.paymentDetails.status = status as PaymentStatus;
+    suppressionData.paymentDetails.status = status;
     SessionService.setSuppressionSession(req, suppressionData);
 
     return res.redirect(redirectURI);

--- a/src/models/PaymentStatus.ts
+++ b/src/models/PaymentStatus.ts
@@ -1,0 +1,6 @@
+export enum PaymentStatus {
+  CREATED = 'created',
+  FAILED = 'failed',
+  CANCELLED = 'cancelled',
+  PAID = 'paid'
+}

--- a/src/models/SuppressionDataModel.ts
+++ b/src/models/SuppressionDataModel.ts
@@ -1,3 +1,5 @@
+import { PaymentStatus } from '../models/PaymentStatus';
+
 export const SUPPRESSION_DATA_KEY: string = 'suppression';
 
 export interface SuppressionData {
@@ -7,7 +9,7 @@ export interface SuppressionData {
   serviceAddress?: Address;
   documentDetails: DocumentDetails;
   contactAddress: Address;
-  paymentStateUUID: string;
+  paymentDetails: PaymentDetails;
 }
 
 export interface ApplicantDetails {
@@ -31,4 +33,10 @@ export interface DocumentDetails {
   companyNumber: string;
   description: string;
   date: string;
+}
+
+export interface PaymentDetails {
+  status: PaymentStatus;
+  stateUUID: string;
+  resourceUri: string;
 }

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -7,6 +7,7 @@ export const SERVICE_ADDRESS_PAGE_URI = `${ROOT_URI}/service-address`;
 export const CONTACT_DETAILS_PAGE_URI = `${ROOT_URI}/contact-details`;
 export const CHECK_SUBMISSION_PAGE_URI = `${ROOT_URI}/check-your-answers`;
 export const PAYMENT_REVIEW_PAGE_URI = `${ROOT_URI}/payment-review`;
+export const PAYMENT_CALLBACK_URI = `${ROOT_URI}/payment-callback`;
 export const CONFIRMATION_PAGE_URI = `${ROOT_URI}/confirmation`;
 
 export const HEALTHCHECK_URI = `/healthcheck`;

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -7,6 +7,7 @@ import { ConfirmationController } from '../controllers/ConfirmationController';
 import { ContactDetailsController } from '../controllers/ContactDetailsController';
 import { DocumentDetailsController } from '../controllers/DocumentDetailsController';
 import { HealthcheckController } from '../controllers/HealthcheckController';
+import { PaymentCallbackController } from '../controllers/PaymentCallbackController';
 import { PaymentReviewController } from '../controllers/PaymentReviewController';
 import { ServiceAddressController } from '../controllers/ServiceAddressController';
 import { StartPageController } from '../controllers/StartPageController';
@@ -21,6 +22,7 @@ import {
   CONTACT_DETAILS_PAGE_URI,
   DOCUMENT_DETAILS_PAGE_URI,
   HEALTHCHECK_URI,
+  PAYMENT_CALLBACK_URI,
   PAYMENT_REVIEW_PAGE_URI,
   ROOT_URI,
   SERVICE_ADDRESS_PAGE_URI
@@ -45,6 +47,7 @@ const serviceAddressController = new ServiceAddressController();
 const contactDetailsController = new ContactDetailsController();
 const checkSubmissionController = new CheckSubmissionController();
 const paymentReviewController = new PaymentReviewController(suppressionService, paymentService);
+const paymentCallbackController = new PaymentCallbackController(paymentService);
 const confirmationController = new ConfirmationController();
 
 const healthcheckController = new HealthcheckController();
@@ -75,6 +78,8 @@ routes.post(CHECK_SUBMISSION_PAGE_URI, checkSubmissionController.confirm);
 
 routes.get(PAYMENT_REVIEW_PAGE_URI, paymentReviewController.renderView);
 routes.post(PAYMENT_REVIEW_PAGE_URI, paymentReviewController.continue);
+
+routes.get(PAYMENT_CALLBACK_URI, paymentCallbackController.checkPaymentStatus);
 
 routes.get(CONFIRMATION_PAGE_URI, confirmationController.renderView);
 

--- a/src/services/payment/PaymentService.ts
+++ b/src/services/payment/PaymentService.ts
@@ -1,11 +1,11 @@
 import { createApiClient } from 'ch-sdk-node';
 import ApiClient from 'ch-sdk-node/dist/client';
-import { CreatePaymentRequest, Payment } from 'ch-sdk-node/dist/services/payment'
-import { ApiResponse } from 'ch-sdk-node/dist/services/resource';
-import { ApiResult } from 'ch-sdk-node/src/services/resource';
+import { CreatePaymentRequest, Payment } from 'ch-sdk-node/dist/services/payment';
+import { ApiResponse, ApiResult } from 'ch-sdk-node/dist/services/resource';
 
+import { PaymentStatus } from '../../models/PaymentStatus';
 import { getConfigValue } from '../../modules/config-handler/ConfigHandler';
-import { CONFIRMATION_PAGE_URI } from '../../routes/paths';
+import { PAYMENT_CALLBACK_URI } from '../../routes/paths';
 
 export class PaymentService {
 
@@ -15,12 +15,12 @@ export class PaymentService {
 
   public constructor() {
     const serviceURL = getConfigValue('CHS_URL');
-    this.redirectUrl = `${serviceURL}${CONFIRMATION_PAGE_URI}`;
+    this.redirectUrl = `${serviceURL}${PAYMENT_CALLBACK_URI}`;
     this.paymentApiUrl = getConfigValue('PAYMENTS_API_URL') as string
     this.suppressionApiUrl = getConfigValue('SUPPRESSIONS_API_URL') as string
   }
 
-  public async generatePaymentUrl(applicationReference: string, paymentStateUUID: string, token: string): Promise<string> {
+  public async generatePaymentUrl(applicationReference: string, paymentStateUUID: string, token: string): Promise<PaymentResource> {
 
     const apiClient: ApiClient = createApiClient(undefined, token, this.paymentApiUrl);
 
@@ -40,9 +40,35 @@ export class PaymentService {
     if (response.isFailure()) {
       const errorResponse = response.value;
       return Promise.reject(
-        new Error(`Failed to initiate payment, status: ${errorResponse.httpStatusCode}, error: ${errorResponse.errors}`))
+        new Error(`Failed to initiate payment - status: ${errorResponse.httpStatusCode}, error: ${errorResponse.errors}`))
     }
     console.log(`${PaymentService.name} - Created payment URL - ${response.value.resource!.links.journey}`);
-    return `${response.value.resource!.links.journey}?summary=false`;
+    return {
+      redirectUrl: `${response.value.resource!.links.journey}?summary=false`,
+      resourceUri: `${response.value.resource!.links.self}`
+    };
   }
+
+  public async getPaymentStatus(paymentResource: string, token: string): Promise<PaymentStatus> {
+    const apiClient: ApiClient = createApiClient(undefined, token, this.paymentApiUrl);
+
+    console.log(`${PaymentService.name} - Making a GET request to ${this.paymentApiUrl}/payments`);
+
+    const response: ApiResult<ApiResponse<Payment>> = await apiClient.payment.getPayment(paymentResource);
+
+    if (response.isFailure()) {
+      const errorResponse = response.value;
+      return Promise.reject(
+        new Error(`Failed to verify payment status - status: ${errorResponse.httpStatusCode}, error: ${errorResponse.errors}`));
+    }
+
+    const paymentStatus = response.value.resource!.status as PaymentStatus;
+    console.log(`${PaymentService.name} - Retrieved payment status - ${paymentStatus}`);
+    return paymentStatus;
+  }
+}
+
+export interface PaymentResource {
+  redirectUrl: string;
+  resourceUri: string;
 }

--- a/test/TestData.ts
+++ b/test/TestData.ts
@@ -46,7 +46,7 @@ export function generateTestData(): SuppressionData {
     paymentDetails: {
       stateUUID: 'asdfghjkl',
       status: 'created',
-      resourceUri: 'paments/TEST12345678'
+      resourceUri: 'payments/TEST12345678'
     } as PaymentDetails,
     applicationReference: 'TEST-TEST'
   } as SuppressionData;

--- a/test/TestData.ts
+++ b/test/TestData.ts
@@ -2,6 +2,7 @@ import {
   Address,
   ApplicantDetails,
   DocumentDetails,
+  PaymentDetails,
   SuppressionData
 } from '../src/models/SuppressionDataModel';
 
@@ -42,7 +43,11 @@ export function generateTestData(): SuppressionData {
       postcode: 'NY',
       country: 'USA'
     } as Address,
-    paymentStateUUID: 'asdfghjkl',
+    paymentDetails: {
+      stateUUID: 'asdfghjkl',
+      status: 'created',
+      resourceUri: 'paments/TEST12345678'
+    } as PaymentDetails,
     applicationReference: 'TEST-TEST'
   } as SuppressionData;
 }

--- a/test/controllers/PaymentCallbackController.test.ts
+++ b/test/controllers/PaymentCallbackController.test.ts
@@ -2,7 +2,11 @@
 import { StatusCodes } from 'http-status-codes';
 import request from 'supertest';
 
-import { PAYMENT_CALLBACK_URI } from '../../src/routes/paths';
+import { PaymentStatus } from '../../src/models/PaymentStatus';
+import { PaymentDetails, SuppressionData } from '../../src/models/SuppressionDataModel';
+import { CONFIRMATION_PAGE_URI, PAYMENT_CALLBACK_URI, PAYMENT_REVIEW_PAGE_URI } from '../../src/routes/paths';
+import { PaymentService } from '../../src/services/payment/PaymentService';
+import SessionService from '../../src/services/session/SessionService';
 import { createApp } from '../ApplicationFactory';
 
 jest.mock('../../src/services/session/SessionService');
@@ -12,27 +16,123 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe('PaymentReviewController', () => {
+describe('PaymentCallbackController', () => {
 
   const app = createApp();
 
-  it('should render error when the required query parameters are not sent', async() => {
+  const queryData = {
+      state: 'LEGIT1234',
+      status: PaymentStatus.PAID,
+      ref: 'TESTA_TESTA'
+  };
+
+  const suppressionData = {
+    paymentDetails: {
+      stateUUID: 'LEGIT1234',
+      resourceUri: 'payments/TEST123456'
+    } as PaymentDetails
+  } as SuppressionData;
+
+  it('should render error when the required query parameters are not sent', async () => {
     await request(app)
       .get(PAYMENT_CALLBACK_URI)
       .expect(response => {
         expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
         expect(response.text).toContain('Sorry, there is a problem with the service');
-      })
+      });
   });
 
-  it('should render error if the payment status is invalid', async() => {
+  it('should render error if the payment status is invalid', async () => {
+
+    const testQuery = { ...queryData };
+    testQuery.status = 'rubbish' as PaymentStatus;
+
     await request(app)
       .get(PAYMENT_CALLBACK_URI)
-      .query({ state: 'TEST', status: 'rubbish', ref: 'TESTA_TESTA' })
+      .query(testQuery)
       .expect(response => {
         expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
         expect(response.text).toContain('Sorry, there is a problem with the service');
-      })
+      });
+  });
+
+  it('should render error when no session present', async () => {
+
+    jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => undefined);
+
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query(queryData)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.text).toContain('Sorry, there is a problem with the service')
+      });
+  });
+
+  it('should render error when payment state has been tampered with', async () => {
+
+    const testQuery = { ...queryData };
+    testQuery.state = 'TAMPERED';
+
+    jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => suppressionData);
+
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query(testQuery)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.text).toContain('Sorry, there is a problem with the service')
+      });
+  });
+
+  it('should redirect the user to the Payment Review page if payment was unsuccessful', async () => {
+
+    const testQuery = { ...queryData };
+    testQuery.status = PaymentStatus.FAILED;
+
+    jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => suppressionData);
+
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query(testQuery)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
+        expect(response.header.location).toEqual(PAYMENT_REVIEW_PAGE_URI)
+      });
+  });
+
+  it('should redirect the user to the Payment Review page if verification of successful payment status failed', async () => {
+
+    jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => suppressionData);
+
+    jest.spyOn(PaymentService.prototype, 'getPaymentStatus').mockImplementationOnce(async () => {
+      return Promise.resolve(PaymentStatus.FAILED);
+    });
+
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query(queryData)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
+        expect(response.header.location).toEqual(PAYMENT_REVIEW_PAGE_URI)
+      });
+  });
+
+  it('should redirect the user to the Confirmation page if payment was successful (and verified)', async () => {
+
+    jest.spyOn(SessionService, 'getSuppressionSession').mockImplementation(() => suppressionData);
+
+    jest.spyOn(PaymentService.prototype, 'getPaymentStatus').mockImplementationOnce(async () => {
+      return Promise.resolve(PaymentStatus.PAID);
+    });
+
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query(queryData)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
+        expect(response.header.location).toEqual(CONFIRMATION_PAGE_URI)
+      });
   });
 
 });

--- a/test/controllers/PaymentCallbackController.test.ts
+++ b/test/controllers/PaymentCallbackController.test.ts
@@ -1,0 +1,38 @@
+
+import { StatusCodes } from 'http-status-codes';
+import request from 'supertest';
+
+import { PAYMENT_CALLBACK_URI } from '../../src/routes/paths';
+import { createApp } from '../ApplicationFactory';
+
+jest.mock('../../src/services/session/SessionService');
+jest.mock('../../src/services/payment/PaymentService');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('PaymentReviewController', () => {
+
+  const app = createApp();
+
+  it('should render error when the required query parameters are not sent', async() => {
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.text).toContain('Sorry, there is a problem with the service');
+      })
+  });
+
+  it('should render error if the payment status is invalid', async() => {
+    await request(app)
+      .get(PAYMENT_CALLBACK_URI)
+      .query({ state: 'TEST', status: 'rubbish', ref: 'TESTA_TESTA' })
+      .expect(response => {
+        expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.text).toContain('Sorry, there is a problem with the service');
+      })
+  });
+
+});

--- a/test/controllers/PaymentReviewController.test.ts
+++ b/test/controllers/PaymentReviewController.test.ts
@@ -54,17 +54,21 @@ describe('PaymentReviewController', () => {
 
     it('should return status code 302 and redirect to GOV Pay', async () => {
 
-      const mockGovPayUrl = 'https://mock.payments.service.gov.uk/v1/payments/123456';
+      const mockRedirectUrl = 'https://mock.payments.service.gov.uk/v1/payments/123456/pay';
+      const mockResourceUri = 'payments/123456';
 
       jest.spyOn(PaymentService.prototype, 'generatePaymentUrl').mockImplementationOnce(async () => {
-        return Promise.resolve(mockGovPayUrl);
+        return Promise.resolve({
+          redirectUrl: mockRedirectUrl,
+          resourceUri: mockResourceUri
+        });
       });
 
       await request(app)
         .post(PAYMENT_REVIEW_PAGE_URI)
         .expect(response => {
           expect(response.status).toEqual(StatusCodes.MOVED_TEMPORARILY);
-          expect(response.header.location).toEqual(mockGovPayUrl)
+          expect(response.header.location).toEqual(mockRedirectUrl)
         });
     });
 

--- a/test/services/payment/PaymentService.test.ts
+++ b/test/services/payment/PaymentService.test.ts
@@ -4,6 +4,7 @@ import { Payment } from 'ch-sdk-node/dist/services/payment'
 import { ApiResponse } from 'ch-sdk-node/dist/services/resource';
 import { failure, success } from 'ch-sdk-node/dist/services/result';
 import { StatusCodes } from 'http-status-codes';
+import { PaymentStatus } from '../../../src/models/PaymentStatus';
 
 import { PaymentResource, PaymentService } from '../../../src/services/payment/PaymentService';
 
@@ -11,49 +12,94 @@ const MockedAPIClient = ApiClient as jest.Mock<ApiClient>;
 const apiClientMock = new MockedAPIClient() as jest.Mocked<ApiClient>;
 
 const mockApplicationReference: string = 'testID';
+const mockResourceUri: string = 'payments/testID'
 const mockPaymentStateUUID: string = '01234567';
 const mockToken: string = 'testToken';
 
 describe('PaymentService', () => {
 
-  it('should initiate GOV Pay payment and return a GOV Pay URL', async () => {
-    const mockUrl = 'http://test.payments.gov.uk/123456';
-    const mockResource = 'payments/TEST123456'
-    const mockResponse = success({
-      resource: {
-        links: {
-          journey: mockUrl,
-          self: mockResource
-        }
-      } as Payment
-    } as ApiResponse<Payment>);
-    const payMock = jest.fn();
-    payMock.mockReturnValue(Promise.resolve(mockResponse));
-    apiClientMock.payment.createPayment = payMock;
+  describe('generatePaymentUrl', () => {
 
-    jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
+    it('should initiate GOV Pay payment and return a GOV Pay URL', async () => {
+      const mockUrl = 'http://test.payments.gov.uk/123456';
+      const mockResource = 'payments/TEST123456'
+      const mockResponse = success({
+        resource: {
+          links: {
+            journey: mockUrl,
+            self: mockResource
+          }
+        } as Payment
+      } as ApiResponse<Payment>);
+      const payMock = jest.fn();
+      payMock.mockReturnValue(Promise.resolve(mockResponse));
+      apiClientMock.payment.createPayment = payMock;
 
-    const paymentService = new PaymentService();
-    const result = await paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken);
-    expect(payMock).toHaveBeenCalled();
-    expect(result.redirectUrl).toEqual(mockUrl + '?summary=false');
-    expect(result.resourceUri).toEqual(mockResource);
-  });
+      jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
 
-  it('should throw an error when the CH Payment Wrapper fails', async () => {
-    const mockResponse = failure({
-      httpStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-      errors: 'Test Error'
+      const paymentService = new PaymentService();
+      const result = await paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken);
+      expect(payMock).toHaveBeenCalled();
+      expect(result.redirectUrl).toEqual(mockUrl + '?summary=false');
+      expect(result.resourceUri).toEqual(mockResource);
     });
-    const payMock = jest.fn();
-    payMock.mockReturnValue(Promise.resolve(mockResponse));
-    apiClientMock.payment.createPayment = payMock;
 
-    jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
+    it('should throw an error when the CH Payment Wrapper fails', async () => {
+      const mockResponse = failure({
+        httpStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errors: 'Test Error'
+      });
+      const payMock = jest.fn();
+      payMock.mockReturnValue(Promise.resolve(mockResponse));
+      apiClientMock.payment.createPayment = payMock;
 
-    const paymentService = new PaymentService();
-    await expect(paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken))
-      .rejects
-      .toThrow('Failed to initiate payment - status: 500, error: Test Error');
+      jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
+
+      const paymentService = new PaymentService();
+      await expect(paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken))
+        .rejects
+        .toThrow('Failed to initiate payment - status: 500, error: Test Error');
+    });
+
   });
+
+  describe('getPaymentStatus', () => {
+
+    it('should retrieve the payment session’s status', async () => {
+      const mockResponse = success({
+        resource: {
+          status: PaymentStatus.PAID
+        } as Payment
+      } as ApiResponse<Payment>);
+      const payMock = jest.fn();
+      payMock.mockReturnValue(Promise.resolve(mockResponse));
+      apiClientMock.payment.getPayment = payMock;
+
+      jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
+
+      const paymentService = new PaymentService();
+      const result = await paymentService.getPaymentStatus(mockResourceUri, mockToken);
+      expect(payMock).toHaveBeenCalled();
+      expect(result).toEqual(PaymentStatus.PAID);
+    });
+
+    it('should throw an error when the CH Payment Wrapper fails', async () => {
+      const mockResponse = failure({
+        httpStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errors: 'Test Error'
+      });
+      const payMock = jest.fn();
+      payMock.mockReturnValue(Promise.resolve(mockResponse));
+      apiClientMock.payment.getPayment = payMock;
+
+      jest.spyOn(nodeSdk, 'createApiClient').mockImplementationOnce(() => apiClientMock);
+
+      const paymentService = new PaymentService();
+      await expect(paymentService.getPaymentStatus(mockResourceUri, mockToken))
+        .rejects
+        .toThrow('Failed to verify payment status - status: 500, error: Test Error');
+    });
+
+  });
+
 });

--- a/test/services/payment/PaymentService.test.ts
+++ b/test/services/payment/PaymentService.test.ts
@@ -5,7 +5,7 @@ import { ApiResponse } from 'ch-sdk-node/dist/services/resource';
 import { failure, success } from 'ch-sdk-node/dist/services/result';
 import { StatusCodes } from 'http-status-codes';
 
-import { PaymentService } from '../../../src/services/payment/PaymentService';
+import { PaymentResource, PaymentService } from '../../../src/services/payment/PaymentService';
 
 const MockedAPIClient = ApiClient as jest.Mock<ApiClient>;
 const apiClientMock = new MockedAPIClient() as jest.Mocked<ApiClient>;
@@ -18,10 +18,12 @@ describe('PaymentService', () => {
 
   it('should initiate GOV Pay payment and return a GOV Pay URL', async () => {
     const mockUrl = 'http://test.payments.gov.uk/123456';
+    const mockResource = 'payments/TEST123456'
     const mockResponse = success({
       resource: {
         links: {
-          journey: mockUrl
+          journey: mockUrl,
+          self: mockResource
         }
       } as Payment
     } as ApiResponse<Payment>);
@@ -34,7 +36,8 @@ describe('PaymentService', () => {
     const paymentService = new PaymentService();
     const result = await paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken);
     expect(payMock).toHaveBeenCalled();
-    expect(result).toEqual(mockUrl + '?summary=false');
+    expect(result.redirectUrl).toEqual(mockUrl + '?summary=false');
+    expect(result.resourceUri).toEqual(mockResource);
   });
 
   it('should throw an error when the CH Payment Wrapper fails', async () => {
@@ -51,6 +54,6 @@ describe('PaymentService', () => {
     const paymentService = new PaymentService();
     await expect(paymentService.generatePaymentUrl(mockApplicationReference, mockPaymentStateUUID, mockToken))
       .rejects
-      .toThrow('Failed to initiate payment, status: 500, error: Test Error');
+      .toThrow('Failed to initiate payment - status: 500, error: Test Error');
   });
 });

--- a/test/services/session/SessionService.test.ts
+++ b/test/services/session/SessionService.test.ts
@@ -6,7 +6,7 @@ import { SuppressionData, SUPPRESSION_DATA_KEY } from '../../../src/models/Suppr
 import SessionService from '../../../src/services/session/SessionService';
 import { generateTestData } from '../../TestData';
 
-const mockSuppressionData: SuppressionData = generateTestData()
+const mockSuppressionData: SuppressionData = generateTestData();
 
 const mockRequestData = {
   session: {

--- a/test/services/session/SessionService.test.ts
+++ b/test/services/session/SessionService.test.ts
@@ -1,48 +1,12 @@
 import { Session } from 'ch-node-session-handler';
-import {SessionKey} from 'ch-node-session-handler/lib/session/keys/SessionKey';
+import { SessionKey } from 'ch-node-session-handler/lib/session/keys/SessionKey';
 import { Request } from 'express';
-import {SuppressionData, SUPPRESSION_DATA_KEY} from '../../../src/models/SuppressionDataModel';
-import SessionService from '../../../src/services/session/SessionService';
 
-const mockSuppressionData: SuppressionData = {
-  applicantDetails: {
-    fullName: 'test-name',
-    emailAddress: 'test-email',
-    dateOfBirth: '1980-01-05'
-  },
-  addressToRemove: {
-    line1: '1 Test Street',
-    line2: '',
-    town: 'Test Town',
-    county: 'Test Midlands',
-    postcode: 'TE10 6ST',
-    country: 'United Kingdom'
-  },
-  serviceAddress: {
-    line1: '2 New Street',
-    line2: '',
-    town: 'A Town',
-    county: 'Mid Lands',
-    postcode: 'AB33 2RR',
-    country: 'UK'
-  },
-  documentDetails: {
-    companyName: 'company-name-test',
-    companyNumber: 'NI000000',
-    description: 'This is a document',
-    date: '2020-01-01'
-  },
-  contactAddress: {
-    line1: '3 Test Street',
-    line2: '',
-    town: 'Test life',
-    county: 'Test bands',
-    postcode: 'A23 4567',
-    country: 'USA'
-  },
-  applicationReference: '123',
-  paymentStateUUID: '1'
-};
+import { SuppressionData, SUPPRESSION_DATA_KEY } from '../../../src/models/SuppressionDataModel';
+import SessionService from '../../../src/services/session/SessionService';
+import { generateTestData } from '../../TestData';
+
+const mockSuppressionData: SuppressionData = generateTestData()
 
 const mockRequestData = {
   session: {


### PR DESCRIPTION
### JIRA

[SR-44: Handling user’s return from the payment provider](https://companieshouse.atlassian.net/browse/SR-44)

### Change Description

Implements payment status checks upon the user's return from GovPay, such that:

- **WHEN** `status` in query string is `"paid"` **AND** status reported by CH Payment API is `"paid"`:
- **THEN** user is redirected to Confirmation page
- **ELSE** user is redirected to Payment Review page

### Testing Details

To simulate payment success / failure, use the corresponding Card Number:

- **Success**: 4444333322221111
- **Fail**: 4000000000000002

### Work Checklist

- [ ] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%