### PR TITLE
chore: remove unrecognised rule from tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -21,7 +21,6 @@
       "member-variable-declaration"
     ],
     "promise-function-async": true,
-    "no-async-without-await": true,
-    "esModuleInterop": true
+    "no-async-without-await": true
   }
 }


### PR DESCRIPTION
### JIRA
NO JIRA

### Change Description

According to the TSLint documentation https://palantir.github.io/tslint/rules/, `esModuleInterop` is not a valid rule. Running `npm run lint` fails with 

```
Could not find implementations for the following rules specified in the configuration:
    esModuleInterop
```
This PR removes `esModuleInterop` from `tslint.json`

### Work Checklist

- [ ] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
