### PR TITLE
Excplicitely disable Docker Builkit in Docker build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Development mode is available for this service in [Docker CHS Development](https
 ## To build the Docker container
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/suppression-web:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/suppression-web:latest .`

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -24,7 +24,7 @@ local_resource(
 
 custom_build(
   ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/suppression-web:latest',
-  command = 'docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [
     sync(
       local_path = './dist',


### PR DESCRIPTION
### JIRA

[Jira Ticket]()

### Change Description

Buildkit is not supported by base images but recently it got enabled by Docker by default. This explicitly disables Buildkit in tilt builds and when image is build manually.

### Page Screenshot



### Work Checklist

- [ ] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
