### PR TITLE
fix: Update title on Address Details page

### DIFF
--- a/src/views/address-to-remove.njk
+++ b/src/views/address-to-remove.njk
@@ -8,7 +8,7 @@
 {% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
 
 {% block pageTitle %}
-  {{ 'Address details' | pageTitle(validationResult) }}
+  {{ 'What home address would you like to remove?' | pageTitle(validationResult) }}
 {% endblock %}
 
 {% block backLink %}

--- a/test/controllers/AddressToRemoveController.test.ts
+++ b/test/controllers/AddressToRemoveController.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../src/services/session/SessionService');
 
 describe('AddressToRemoveController', () => {
 
-  const pageTitle = 'Address details';
+  const pageTitle = 'What home address would you like to remove\\?';
   const app = createApp();
 
   describe('on GET', () => {


### PR DESCRIPTION
### JIRA

[Content Changes - Address Details page](https://companieshouse.atlassian.net/browse/SR-132)

### Change Description

Updates the page title of the Address Details page to "What home address would you like to remove?", in line with V4 of the prototype.

### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%